### PR TITLE
recursive contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,20 @@ A wrapper around the React Context API.
 
 ### 1. Simple example
 
-**1**. Define your context and pass it to the `createSuperContext`-function.
-```typescript
-// CounterContext.ts
-export const Counter = () => {
-    const [count, setCount] = useState(0);
-
-    return {count, setCount};
-};
-
-export const useCounter = createSuperContext(Counter);
+**1**. Use the `createSuperContext`-function to create your context. It takes a function that returns the state and returns a context object as well as a hook to access the state. 
+```javascript
+// CounterContext.js
+export const [counter, useCounter] = createSuperContext(() => {
+  const [count, setCount] = useState(0);
+  return {count, setCount};
+});
 ```
-**2**. Add the `SuperContext` in your app and pass it your contexts. 
-```typescript jsx
-// App.tsx
+**2**. Add the `SuperContext` in your app and pass it the context (`counter`) created by the `createSuperContext` call. 
+```javascript
+// App.jsx
 const App = () => (
     <div>
-        <SuperContext contexts={[Counter]}>
+        <SuperContext contexts={[counter]}>
             <CountDisplay/>
             <CounterButton/>
         </SuperContext>
@@ -31,83 +28,56 @@ const App = () => (
 ```
 
 **3**. Consume the context in your components.
-```typescript jsx
-// CountDisplay.tsx
+```javascript
+// CountDisplay.jsx
 export const CountDisplay = () => {
     const {count} = useCounter();
     return <div>{count}</div>;
 };
 
-// CounterButton.tsx 
+// CounterButton.jsx 
 export const CounterButton = () => {
     const {count, setCount} = useCounter();
     return <button onClick={() => setCount(count + 1)}>+1</button>;
 };
 ```
 
-### 2. Use a context from another context
+### 2. TypeScript
 
-The super context's state isn't updated until all its sub-contexts have been evaluated so if you want to share values between sub-contexts, you must pass the state argument to the hook. You are then able to access values of any of the previous sub-contexts in SuperContext's list.
-
-```typescript jsx
-// EvenOrOddContext.ts
-export const EvenOrOdd = (state: any) => {
-    const {count} = useCounter(state);
-    return count % 2 === 0 ? "even" : "odd";
-};
-
-export const useEvenOrOdd = createSuperContext<string>(EvenOrOdd);
-
-// App.tsx
-const App = () => (
-    <div>
-        <SuperContext contexts={[Counter, EvenOrOdd]}> {/* The order is important */}
-            <CountDisplay/>
-            <CounterButton/>
-        </SuperContext>
-    </div>
-);
-```
-
-### 3. TypeScript
-
-**1**. Type inferred from context function's return type.
-```typescript jsx
+**1**. Type given explicitly in `createSuperContext` call.
+```typescript
 // CounterContext.ts
-interface CounterContext {
+export interface CounterContext {
     count: number;
     increment: () => void;
     decrement: () => void;
 }
 
-export function Counter(): CounterContext {
+export const [counter, useCounter] = createSuperContext<CounterContext>(() => {
     const [count, setCount] = useState(0);
 
     const increment = () => setCount(count + 1);
     const decrement = () => setCount(Math.max(0, count - 1));
 
     return {count, increment, decrement};
-}
-
-export const useCounter = createSuperContext(Counter);
+});
 ```
 
-**2**. Type given explicitly in `createSuperContext` call.
+**2**. Type inferred from context function's return type.
 ```typescript
 // EvenOrOddContext.ts
-export const EvenOrOdd = (state: any) => {
-    const {count} = useCounter(state);
-    return count % 2 === 0 ? "even" : "odd";
-};
+export const [evenOrOdd, useEvenOrOdd] = createSuperContext(() => {
+    const {count} = useCounter();
 
-export const useEvenOrOdd = createSuperContext<string>(EvenOrOdd);
+    return count % 2 === 0 ? "even" : "odd";
+});
 ```
 
 **3**. Types inferred when consuming the context
 ```typescript jsx
 export const CountDisplay = () => {
     const {count} = useCounter(); // inferred type: CounterContext
-    const evenOrOdd = useEvenOrOdd(); // inferred type: string
+    const evenOrOdd = useEvenOrOdd(); // inferred type: "even" | "odd"
 
     return <div>{count} ({evenOrOdd})</div>;
 };

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-super-context
 
-A wrapper around the React Context API.
+A wrapper around the React Context API. Makes it easy to create and consume contexts without having to write a lot of boilerplate.
 
 ## Examples
 
@@ -42,7 +42,34 @@ export const CounterButton = () => {
 };
 ```
 
-### 2. TypeScript
+### 2. Use multiple contexts
+
+**1**. Add a second context that uses `useCounter`.
+
+```javascript
+// EvenOrOddContext.ts
+export const [evenOrOdd, useEvenOrOdd] = createSuperContext(() => {
+    const {count} = useCounter();
+    return count % 2 === 0 ? "even" : "odd";
+});
+```
+
+**2**. Remember to add it to the contexts lists. The order of the contexts matters.
+```javascript
+// App.jsx
+const App = () => (
+    <div>
+        <SuperContext contexts={[counter, evenOrOdd]}>
+            <CountDisplay/>
+            <CounterButton/>
+        </SuperContext>
+    </div>
+);
+```
+
+`evenOrOdd` depends on `counter` so if they were given the other way around (`contexts={[evenOrOdd, counter]}`), then `useEvenOrOdd` wouldn't work correctly.
+
+### 3. TypeScript
 
 **1**. Type given explicitly in `createSuperContext` call.
 ```typescript

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A wrapper around the React Context API. Makes it easy to create and consume cont
 
 ### 1. Simple example
 
-**1**. Use the `createSuperContext`-function to create your context. It takes a function that returns the state and returns a context object as well as a hook to access the state. 
+**1**. Use the `createSuperContext` function to create your context. It takes a function that returns the state and returns a context object as well as a hook to access the state. 
 ```javascript
 // CounterContext.js
 export const [counter, useCounter] = createSuperContext(() => {
@@ -69,7 +69,33 @@ const App = () => (
 
 `evenOrOdd` depends on `counter` so if they were given the other way around (`contexts={[evenOrOdd, counter]}`), then `useEvenOrOdd` wouldn't work correctly.
 
-### 3. TypeScript
+**3**. Consume the new context.
+
+```javascript
+// CountDisplay.jsx
+export const CountDisplay = () => {
+    const {count} = useCounter();
+    const evenOrOdd = useEvenOrOdd();
+
+    return <div>{count} ({evenOrOdd})</div>;
+};
+```
+
+### 3. Use hooks as you normally would
+```javascript
+export const [logging] = createSuperContext(() => {
+    const {count} = useCounter();
+    const evenOrOdd = useEvenOrOdd();
+
+    useEffect(() => {
+        console.log(`The current count is ${count} which is ${evenOrOdd}`);
+    }, [count, evenOrOdd]);
+});
+```
+
+Remember to always add your context objects to the `SuperContext` component.
+
+### 4. TypeScript
 
 **1**. Type given explicitly in `createSuperContext` call.
 ```typescript
@@ -95,7 +121,6 @@ export const [counter, useCounter] = createSuperContext<CounterContext>(() => {
 // EvenOrOddContext.ts
 export const [evenOrOdd, useEvenOrOdd] = createSuperContext(() => {
     const {count} = useCounter();
-
     return count % 2 === 0 ? "even" : "odd";
 });
 ```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import {SuperContext} from "./Context/SuperContext";
 import {CountDisplay} from "./CountDisplay";
 import {CounterButton} from "./CounterButton";
-import {EvenOrOdd} from "./Context/EvenOrOddContext";
-import {Counter} from "./Context/CounterContext";
-import {Logging} from "./Context/LoggingContext";
+import {evenOrOdd} from "./Context/EvenOrOddContext";
+import {counter} from "./Context/CounterContext";
+import {logging} from "./Context/LoggingContext";
 
 const App = () => (
     <div>
         <SuperContext contexts={[
-            Counter,
-            EvenOrOdd,
-            Logging
+            counter,
+            evenOrOdd,
+            logging
         ]}>
-            <CountDisplay/>
-            <CounterButton/>
+                <CountDisplay/>
+                <CounterButton/>
         </SuperContext>
     </div>
 );

--- a/src/Context/CounterContext.ts
+++ b/src/Context/CounterContext.ts
@@ -7,13 +7,11 @@ export interface CounterContext {
     decrement: () => void;
 }
 
-export function Counter(): CounterContext {
+export const [counter, useCounter] = createSuperContext<CounterContext>(() => {
     const [count, setCount] = useState(0);
 
     const increment = () => setCount(count + 1);
     const decrement = () => setCount(Math.max(0, count - 1));
 
     return {count, increment, decrement};
-}
-
-export const useCounter = createSuperContext(Counter);
+});

--- a/src/Context/EvenOrOddContext.ts
+++ b/src/Context/EvenOrOddContext.ts
@@ -1,7 +1,7 @@
 import {createSuperContext} from "./SuperContext";
 import {useCounter} from "./CounterContext";
 
-export const [evenOrOdd, useEvenOrOdd] = createSuperContext<string>(() => {
+export const [evenOrOdd, useEvenOrOdd] = createSuperContext(() => {
     const {count} = useCounter();
 
     return count % 2 === 0 ? "even" : "odd";

--- a/src/Context/EvenOrOddContext.ts
+++ b/src/Context/EvenOrOddContext.ts
@@ -1,11 +1,9 @@
-import {ContextMap, createSuperContext} from "./SuperContext";
+import {createSuperContext} from "./SuperContext";
 import {useCounter} from "./CounterContext";
 
-export const EvenOrOdd = (state: ContextMap) => {
-    const {count} = useCounter(state);
+export const [evenOrOdd, useEvenOrOdd] = createSuperContext<string>(() => {
+    const {count} = useCounter();
 
     return count % 2 === 0 ? "even" : "odd";
-};
-
-export const useEvenOrOdd = createSuperContext<string>(EvenOrOdd);
+});
 

--- a/src/Context/LoggingContext.ts
+++ b/src/Context/LoggingContext.ts
@@ -1,14 +1,13 @@
 import {useEffect} from "react";
 import {useCounter} from "./CounterContext";
 import {useEvenOrOdd} from "./EvenOrOddContext";
-import {ContextMap} from "./SuperContext";
+import {createSuperContext} from "./SuperContext";
 
-export const Logging = (state: ContextMap) => {
-    const {count} = useCounter(state);
-    const evenOrOdd = useEvenOrOdd(state);
+export const [logging] = createSuperContext(() => {
+    const {count} = useCounter();
+    const evenOrOdd = useEvenOrOdd();
 
     useEffect(() => {
         console.log(`The current count is ${count} which is ${evenOrOdd}`);
     }, [count, evenOrOdd]);
-};
-
+});

--- a/src/Context/SuperContext.tsx
+++ b/src/Context/SuperContext.tsx
@@ -15,8 +15,9 @@ const SubContextProvider = ({contexts, index, children}: SuperContextProps & { i
 
     return createElement(
         contexts[index].context.Provider,
-        {value}, index + 1 < contexts.length ?
-        <SubContextProvider contexts={contexts} index={index + 1}>{children}</SubContextProvider> : children);
+        {value},
+        index + 1 < contexts.length ?
+            <SubContextProvider contexts={contexts} index={index + 1}>{children}</SubContextProvider> : children);
 };
 
 export function createSuperContext<T>(hook: () => T): [SubContext<T>, () => T] {

--- a/src/Context/SuperContext.tsx
+++ b/src/Context/SuperContext.tsx
@@ -1,33 +1,26 @@
-import React, {createContext, PropsWithChildren, useContext} from "react";
+import React, {Context, createContext, createElement, PropsWithChildren, useContext} from "react";
 
-export type SubContext<T = any> = (state?: any) => T;
-export type ContextMap = Map<SubContext, any>;
-export type SuperContextProps = PropsWithChildren<{ contexts: SubContext[] }>;
-
-const Super = createContext<ContextMap>(new Map<SubContext, any>());
-
-export const SuperContext = ({contexts, children}: SuperContextProps) => {
-    const map = new Map<SubContext, any>();
-
-    for (let context of contexts) {
-        map.set(context, context(map));
-    }
-    return <Super.Provider value={map}>{children}</Super.Provider>;
-};
-
-function useSuperContext<T = any>(context: SubContext<T>, state?: ContextMap): T {
-    const contextMap = useContext(Super);
-    // check 'has' first because 'get' can return undefined and still be valid
-    if (contextMap.has(context)) return contextMap.get(context) as T;
-
-    if (!state?.has(context)) {
-        throw Error(`Unknown context '${context.name}'. Did you add it to the subContexts list? ` +
-            'If this is called from another SuperContext make sure you\'re passing the state argument.')
-    }
-
-    return state!.get(context) as T;
+interface SubContext<T = any> {
+    context: Context<T>;
+    hook: () => T
 }
 
-export function createSuperContext<T>(context: SubContext<T>) {
-    return (state?: ContextMap) => useSuperContext(context, state);
+export type SuperContextProps = PropsWithChildren<{ contexts: SubContext[] }>;
+
+export const SuperContext = ({contexts, children}: SuperContextProps) =>
+    <SubContextProvider contexts={contexts} index={0}>{children}</SubContextProvider>;
+
+const SubContextProvider = ({contexts, index, children}: SuperContextProps & { index: number }) => {
+    const value = contexts[index].hook();
+
+    return createElement(
+        contexts[index].context.Provider,
+        {value}, index + 1 < contexts.length ?
+        <SubContextProvider contexts={contexts} index={index + 1}>{children}</SubContextProvider> : children);
+};
+
+export function createSuperContext<T>(hook: () => T): [SubContext<T>, () => T] {
+    const context = createContext<T>({} as T);
+    const useContextHook = () => useContext<T>(context);
+    return [{context, hook}, useContextHook];
 }


### PR DESCRIPTION
Rewrite SuperContext to recursively create context providers. No longer have to pass state through context hooks.